### PR TITLE
Bleak refactoring, optional MQTT, more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__
 *.local
+.venv
+.idea

--- a/config.py
+++ b/config.py
@@ -14,6 +14,7 @@ DEVICES = [
 
 # MQTT Settings
 
+MQTT_ENABLE=False                       # Enable MQTT. Publish MQTT messages or just print output. Default: True
 MQTT_HOST="127.0.0.1"                   # MQTT Server (defaults to 127.0.0.1)
 MQTT_PORT=1883                          # Defaults to 1883
 MQTT_USERNAME="username"                # Username for MQTT server ('username' if not required)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-bleak==0.14.3
-paho-mqtt==1.6.1
+bleak==1.0.1
+paho-mqtt==2.1.0


### PR DESCRIPTION
I'm also an owner of these cheap terrible clone sensors and your project seemed like an easy and fast starting point! (Thank you for the reverse-engineering of the protocol!). I just wanted to implement an option to disable MQTT, but....
I ran into some problems though, especially because you were using a very old bleak.....so this tiny project already became bigger ;) 

This PR
* bumps bleak and paho-mqtt
* adds MQTT_ENABLE to config. When set to False mqtt is left aside
* refactors a large part of the ble(bleak) handling. It's WIP, but it works.
* some more