### PR TITLE
Name is now preferred over address in mqtt messages

### DIFF
--- a/ble-lt-thermometer.py
+++ b/ble-lt-thermometer.py
@@ -143,7 +143,7 @@ def notification_handler(_: int, data: bytearray, client: BleakClient, deviceCfg
         }
         print(result)
         mqtt_send_state(client, result)
-        if hasattr(deviceCfg, "domoticz_idx"):
+        if hasattr(deviceCfg, "domoticz_idx") and deviceCfg.domoticz_idx > 0:
             mqtt_send_domoticz(client, deviceCfg.domoticz_idx, result)
 
         return

--- a/ble-lt-thermometer.py
+++ b/ble-lt-thermometer.py
@@ -1,12 +1,15 @@
 import asyncio
 from functools import partial
 from typing import Optional
+from time import sleep
+import bleak
+
+import paho.mqtt.publish as publish
 import json
 import re
 
 from bleak import BleakScanner, BleakClient
 from bleak.exc import BleakDBusError
-import paho.mqtt.publish as publish
 
 import config
 

--- a/ble-lt-thermometer.py
+++ b/ble-lt-thermometer.py
@@ -14,12 +14,12 @@ from bleak.exc import BleakDBusError
 import config
 
 # Install requirements :
-# pip3 install bleak paho-mqtt
+# pip3 install -r requirements.txt
 #
 # Edit config in config.py
 
 
-# The UUID of LT Thermometer v3 protocol
+# The UUID of LT Thermometer v3 & v4 protocol
 service_uuid = "0000FFE5-0000-1000-8000-00805f9b34fb"
 notify_uuid = "0000FFE8-0000-1000-8000-00805f9b34fb"
 char_uuid = "00002902-0000-1000-8000-00805f9b34fb"

--- a/ble-lt-thermometer.py
+++ b/ble-lt-thermometer.py
@@ -1,15 +1,12 @@
 import asyncio
 from functools import partial
 from typing import Optional
-from time import sleep
-import bleak
-
-import paho.mqtt.publish as publish
 import json
 import re
 
 from bleak import BleakScanner, BleakClient
 from bleak.exc import BleakDBusError
+import paho.mqtt.publish as publish
 
 import config
 

--- a/ble-lt-thermometer.py
+++ b/ble-lt-thermometer.py
@@ -1,15 +1,13 @@
 import asyncio
 from functools import partial
 from typing import Optional
-from time import sleep
-import bleak
-
-import paho.mqtt.publish as publish
 import json
 import re
 
+import bleak
 from bleak import BleakScanner, BleakClient
 from bleak.exc import BleakDBusError
+import paho.mqtt.publish as publish
 
 import config
 

--- a/ble-lt-thermometer.py
+++ b/ble-lt-thermometer.py
@@ -138,7 +138,7 @@ def notification_handler(_: int, data: bytearray, client: BleakClient, deviceCfg
         result = {
             "temperature": toSigned16(data[5:7]) / 10.0,
             "humidity": ((data[7] << 8) + data[8]) / 10.0,
-            "power": data[9],
+            "power": data[9] * 100,
             "unit": "Celsius" if data[10] == 0 else "Fahrenheit"
         }
         print(result)

--- a/ble-lt-thermometer.py
+++ b/ble-lt-thermometer.py
@@ -141,7 +141,7 @@ def notification_handler(_: int, data: bytearray, client: BleakClient, deviceCfg
             "temperature": toSigned16(data[5:7]) / 10.0,
             "humidity": ((data[7] << 8) + data[8]) / 10.0,
             "power": data[9],
-            "unit": "Celcius" if data[10] == 0 else "Farenheit"
+            "unit": "Celsius" if data[10] == 0 else "Fahrenheit"
         }
         print(result)
         mqtt_send_state(client, result)
@@ -199,7 +199,7 @@ async def deviceConnect(deviceCfg: Device):
 
         await disconnected_event.wait()
 
-    print("Too much error, stopping")
+    print("Too many errors, stopping")
     
 
 async def main(devicesCfg: list):


### PR DESCRIPTION
MQTT messages should send name instead of address when name is set. Name is now preferred over address in mqtt messages. Resolves #2