### PR TITLE
remove power from state message in favor of battery 

### DIFF
--- a/ble-lt-thermometer.py
+++ b/ble-lt-thermometer.py
@@ -191,7 +191,6 @@ def notification_handler(_: int, data: bytearray, device: Device):
         result = {
             "temperature": toSigned16(data[5:7]) / 10.0,
             "humidity": ((data[7] << 8) + data[8]) / 10.0,
-            "power": data[9] * 100,
             "battery": data[9] * 100,
             "unit": "Celsius" if data[10] == 0 else "Fahrenheit"
         }


### PR DESCRIPTION
remove power from state message in favor of battery to be consistent with hass; uses battery which has been implemented