### PR TITLE
Remove attempts at battery-saving workarounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ data from cheap bluetooth LT Thermometer sensors.
 Currently, protocol versions 3 and 4 are supported. Other versions might be supported as well, as there seems to be
 little to no changes in between 3 and 4.
 
+**Note for V3 users:**  
+It is very likely V3 users will experience a battery drain issue which seems to be fixed in V4 devices. This is the 
+main reason the workarounds in **blelt2mqtt** attempting to resolve this issue have been removed. Please feel 
+free to file an issue in case you are using a V3 device and experiencing the battery drain mentioned.
+
 
 |                              Device                               | Protocol Version | Article # | Model # |                           Photo                            | Where to find (examples)                                         |
 |:-----------------------------------------------------------------:|------------------|-----------|---------|:----------------------------------------------------------:|------------------------------------------------------------------| 

--- a/ble-lt-thermometer.py
+++ b/ble-lt-thermometer.py
@@ -269,8 +269,7 @@ def notification_handler(_: int, data: bytearray, device: Device):
     Log.msg(msg, level="DEBUG")
 
     return
-    #client.disconnect()
-    
+
 async def deviceConnect(device: Device):
     while True:
         Log.msg(f'Scanning for device {device.name}')

--- a/ble-lt-thermometer.py
+++ b/ble-lt-thermometer.py
@@ -85,7 +85,6 @@ class Device:
     custom_name: Optional[str] = ""
     _safe_name: str = ""
     mac: str = ""
-    wait: int = 30
     _uniq_id = ""
     domoticz_idx: Optional[int] = 0
 

--- a/ble-lt-thermometer.py
+++ b/ble-lt-thermometer.py
@@ -312,8 +312,7 @@ async def deviceConnect(device: Device):
                 mqtt_send_discovery(device)
 
                 await client.start_notify(notify_uuid, partial(notification_handler, device=device))
-                await asyncio.sleep(device.wait)
-                await client.stop_notify(notify_uuid)
+                await asyncio.sleep(10)
 
                 try:
                     await disconnected_event.wait()

--- a/blelt.sh
+++ b/blelt.sh
@@ -1,11 +1,4 @@
 #!/bin/bash
 
-
-#MY_PWD="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 MY_PWD="$( dirname -- "$( readlink -f -- "$0"; )" )";
-
-
-while true; do
-sleep 30
 { python3 "$MY_PWD/ble-lt-thermometer.py" > "$MY_PWD/blelt.logs"; } 2>&1
-done

--- a/config.py
+++ b/config.py
@@ -3,12 +3,11 @@
 #   'mac'         : (required) MAC Address of the bluetooth LT Thermometer
 #   'custom_name' : (optional) to override the name provided by bluetooth
 #   'domoticz_idx': (optional) id of the virtual sensor to be updated through domoticz
-#   'wait'        : (optional) time in seconds to wait between two measures (disconnect/reconnect)
 # }
 
 DEVICES = [
-   {'mac': "C8:33:DE:43:2C:00", 'custom_name': "LT Bureau", 'domoticz_idx': 96, 'wait': 30},
-   {'mac': "C8:33:DE:43:2C:01", 'custom_name': "LT Bureau (14)", 'domoticz_idx': 39, 'wait': 30},
+   {'mac': "C8:33:DE:43:2C:00", 'custom_name': "LT Bureau", 'domoticz_idx': 96},
+   {'mac': "C8:33:DE:43:2C:01", 'custom_name': "LT Bureau (14)", 'domoticz_idx': 39},
 ]
 
 # Logging


### PR DESCRIPTION
- remove disconnect from notification_handler
- remove stop_notify from deviceConnect, while retaining a 10 second sleep to give the if some rest
- remove wait attribute from config and device class
- remove loop and sleep from blelt.sh. blelt.sh is further refactored in blelt2mqtt-package branch
- add note about battery drain for V3 users to README