### PR TITLE
Implement configurable device registry properties

### DIFF
--- a/blelt2mqtt.py
+++ b/blelt2mqtt.py
@@ -151,7 +151,16 @@ class Device:
     Device class.
     Acts as object holding device configuration
     """
+    # Device properties
+    manufacturer: str = ""
+    model: str = ""
+    model_id: Optional[str] = ""
+    hardware_version: str = ""
+    software_version: str = ""
+    suggested_area: str = ""
+    serial_number: Optional[str] = ""
 
+    # Component properties
     _name: str = ""
     custom_name: Optional[str] = ""
     _safe_name: str = ""
@@ -245,6 +254,13 @@ class MQTT:
                 "device": {
                     "ids": device.safe_name,
                     "name": device.name,
+                    "manufacturer": device.manufacturer,
+                    "model": device.model,
+                    "model_id": device.model_id,
+                    "hw_version": device.hardware_version,
+                    "sw_version": device.software_version,
+                    "suggested_area": device.suggested_area,
+                    "serial_number": device.serial_number,
                 },
                 "origin": {
                     "name": "blelt2mqtt",
@@ -521,9 +537,15 @@ async def main(devicesCfg: list):
 if __name__ == "__main__":
     config = Config()
 
+    # TODO: mapper :)
+    # Get default device properties
+    defaults = config.getValue("device_defaults")
     # Instantiate device objects from config
     devices = []
     for device_cfg in config.getValue("devices"):
+        for default in defaults.items():
+            device_cfg.setdefault(default[0], default[1])
+
         devices.append(Device(device_cfg))
 
     try:

--- a/config-default.yaml
+++ b/config-default.yaml
@@ -1,6 +1,18 @@
-# Device Settings
+# Devices
 #
+# Default device settings.
+# These defaults are used for all the configured devices below, and can be overridden on a per-device level.
+device_defaults:
+    manufacturer: blelt2mqtt
+    model: lt
+    #model_id:
+    hardware_version: v4
+    software_version: v0.2.0
+    suggested_area: living_room
+    #serial_number:
+
 # Configure your sensors below. Configuration is simply done by adding them to this list.
+# Any of the device_defaults attributes above can be used per device.
 #
 # mac:          (required) MAC Address of the bluetooth LT Thermometer
 # custom_name:  (optional) to override the name provided by bluetooth


### PR DESCRIPTION
- add device registry properties to config-default.yaml
- implement configurable device registry properties in blelt2mqtt.py